### PR TITLE
ユーザーエージェントの設定、ダウンロードされたサイズがおかしいときのエラー追加

### DIFF
--- a/source/AviUtlAutoInstaller/ViewModels/InstallEditViewModel.cs
+++ b/source/AviUtlAutoInstaller/ViewModels/InstallEditViewModel.cs
@@ -981,6 +981,7 @@ namespace AviUtlAutoInstaller.ViewModels
                     break;
                 case DownloadResult.DownloadSizeGetError:
                 case DownloadResult.DownloadFileNameGetError:
+                case DownloadResult.DownloadSizeMismatchError:
                 case DownloadResult.DownloadError:
                     message = "ダウンロードに失敗しました。";
                     break;


### PR DESCRIPTION
Fixes #7 

ユーザーエージェントを追加しました。「AviUtlAutoInstaller」に設定してあります。
また、ダウンロードサイズがおかしくてもダウンロード成功になっていたので新規に「DownloadSizeMismatchError」を追加してエラー判定することにしました。

これによりauls氏のPNG出力プラグインがダウンロードできないバグが修正されます。