### PR TITLE
updated library version in vulnerabilities detected

### DIFF
--- a/source/AviUtlAutoInstaller/AviUtlAutoInstaller.csproj
+++ b/source/AviUtlAutoInstaller/AviUtlAutoInstaller.csproj
@@ -200,10 +200,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AngleSharp">
-      <Version>0.16.1</Version>
+      <Version>1.6.0</Version>
     </PackageReference>
     <PackageReference Include="Costura.Fody">
-      <Version>5.7.0</Version>
+      <Version>6.2.0</Version>
       <IncludeAssets>runtime; compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/AviUtlAutoInstaller/FodyWeavers.xsd
+++ b/source/AviUtlAutoInstaller/FodyWeavers.xsd
@@ -27,14 +27,39 @@
                   <xs:documentation>A list of runtime assembly names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="ExcludeRuntimes" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of runtimes to exclude from the default action of "embed all Copy Local references", delimited with line breaks</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="IncludeRuntimes" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of runtimes names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="Unmanaged32Assemblies" type="xs:string">
                 <xs:annotation>
-                  <xs:documentation>A list of unmanaged 32 bit assembly names to include, delimited with line breaks.</xs:documentation>
+                  <xs:documentation>Obsolete, use UnmanagedWinX86Assemblies instead</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="UnmanagedWinX86Assemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of unmanaged X86 (32 bit) assembly names to include, delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="Unmanaged64Assemblies" type="xs:string">
                 <xs:annotation>
-                  <xs:documentation>A list of unmanaged 64 bit assembly names to include, delimited with line breaks.</xs:documentation>
+                  <xs:documentation>Obsolete, use UnmanagedWinX64Assemblies instead.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="UnmanagedWinX64Assemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of unmanaged X64 (64 bit) assembly names to include, delimited with line breaks.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="UnmanagedWinArm64Assemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of unmanaged Arm64 (64 bit) assembly names to include, delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="PreloadOrder" type="xs:string">
@@ -73,6 +98,11 @@
                 <xs:documentation>As part of Costura, embedded assemblies are no longer included as part of the build. This cleanup can be turned off.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="DisableEventSubscription" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>The attach method no longer subscribes to the `AppDomain.AssemblyResolve` (.NET 4.x) and `AssemblyLoadContext.Resolving` (.NET 6.0+) events.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="LoadAtModuleInit" type="xs:boolean">
               <xs:annotation>
                 <xs:documentation>Costura by default will load as part of the module initialization. This flag disables that behavior. Make sure you call CosturaUtility.Initialize() somewhere in your code.</xs:documentation>
@@ -105,12 +135,27 @@
             </xs:attribute>
             <xs:attribute name="Unmanaged32Assemblies" type="xs:string">
               <xs:annotation>
-                <xs:documentation>A list of unmanaged 32 bit assembly names to include, delimited with |.</xs:documentation>
+                <xs:documentation>Obsolete, use UnmanagedWinX86Assemblies instead</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UnmanagedWinX86Assemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of unmanaged X86 (32 bit) assembly names to include, delimited with |.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="Unmanaged64Assemblies" type="xs:string">
               <xs:annotation>
-                <xs:documentation>A list of unmanaged 64 bit assembly names to include, delimited with |.</xs:documentation>
+                <xs:documentation>Obsolete, use UnmanagedWinX64Assemblies instead</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UnmanagedWinX64Assemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of unmanaged X64 (64 bit) assembly names to include, delimited with |.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UnmanagedWinArm64Assemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of unmanaged Arm64 (64 bit) assembly names to include, delimited with |.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="PreloadOrder" type="xs:string">

--- a/source/AviUtlAutoInstaller/Properties/AssemblyInfo.cs
+++ b/source/AviUtlAutoInstaller/Properties/AssemblyInfo.cs
@@ -49,4 +49,4 @@ using System.Windows;
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.8.0.0")]
+[assembly: AssemblyVersion("1.9.0.0")]

--- a/source/Updater/FodyWeavers.xsd
+++ b/source/Updater/FodyWeavers.xsd
@@ -27,14 +27,39 @@
                   <xs:documentation>A list of runtime assembly names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="ExcludeRuntimes" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of runtimes to exclude from the default action of "embed all Copy Local references", delimited with line breaks</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="IncludeRuntimes" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of runtimes names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="Unmanaged32Assemblies" type="xs:string">
                 <xs:annotation>
-                  <xs:documentation>A list of unmanaged 32 bit assembly names to include, delimited with line breaks.</xs:documentation>
+                  <xs:documentation>Obsolete, use UnmanagedWinX86Assemblies instead</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="UnmanagedWinX86Assemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of unmanaged X86 (32 bit) assembly names to include, delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="Unmanaged64Assemblies" type="xs:string">
                 <xs:annotation>
-                  <xs:documentation>A list of unmanaged 64 bit assembly names to include, delimited with line breaks.</xs:documentation>
+                  <xs:documentation>Obsolete, use UnmanagedWinX64Assemblies instead.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="UnmanagedWinX64Assemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of unmanaged X64 (64 bit) assembly names to include, delimited with line breaks.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="UnmanagedWinArm64Assemblies" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of unmanaged Arm64 (64 bit) assembly names to include, delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="PreloadOrder" type="xs:string">
@@ -73,6 +98,11 @@
                 <xs:documentation>As part of Costura, embedded assemblies are no longer included as part of the build. This cleanup can be turned off.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="DisableEventSubscription" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>The attach method no longer subscribes to the `AppDomain.AssemblyResolve` (.NET 4.x) and `AssemblyLoadContext.Resolving` (.NET 6.0+) events.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="LoadAtModuleInit" type="xs:boolean">
               <xs:annotation>
                 <xs:documentation>Costura by default will load as part of the module initialization. This flag disables that behavior. Make sure you call CosturaUtility.Initialize() somewhere in your code.</xs:documentation>
@@ -105,12 +135,27 @@
             </xs:attribute>
             <xs:attribute name="Unmanaged32Assemblies" type="xs:string">
               <xs:annotation>
-                <xs:documentation>A list of unmanaged 32 bit assembly names to include, delimited with |.</xs:documentation>
+                <xs:documentation>Obsolete, use UnmanagedWinX86Assemblies instead</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UnmanagedWinX86Assemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of unmanaged X86 (32 bit) assembly names to include, delimited with |.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="Unmanaged64Assemblies" type="xs:string">
               <xs:annotation>
-                <xs:documentation>A list of unmanaged 64 bit assembly names to include, delimited with |.</xs:documentation>
+                <xs:documentation>Obsolete, use UnmanagedWinX64Assemblies instead</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UnmanagedWinX64Assemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of unmanaged X64 (64 bit) assembly names to include, delimited with |.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UnmanagedWinArm64Assemblies" type="xs:string">
+              <xs:annotation>
+                <xs:documentation>A list of unmanaged Arm64 (64 bit) assembly names to include, delimited with |.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
             <xs:attribute name="PreloadOrder" type="xs:string">

--- a/source/Updater/Updater.csproj
+++ b/source/Updater/Updater.csproj
@@ -144,10 +144,10 @@
   <ItemGroup />
   <ItemGroup>
     <PackageReference Include="AngleSharp">
-      <Version>0.16.1</Version>
+      <Version>1.6.0</Version>
     </PackageReference>
     <PackageReference Include="Costura.Fody">
-      <Version>5.7.0</Version>
+      <Version>6.2.0</Version>
       <IncludeAssets>runtime; compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Angle Sharp: 0.16.1 -> 1.6.0
- Costura.Fody: 5.7.0 -> 6.2.0\
   Dependent libraries used in Costura.Fody.(now version in unused)
   - System.Net.Http: 4.3.0 -> deleted
   - System.Text.RegularExpressions: 4.3.0 -> deleted